### PR TITLE
新增 axios 请求组件

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+## 请求组件说明
+
+项目提供了基于 axios 的请求封装，文件位于 `src/api/request.ts`，已配置请求和响应拦截器，会自动携带本地 token 并在出错时提示。
+
+### 基本用法
+
+```ts
+import { get, post } from '@/api'
+
+get('/example').then(({ result }) => {
+    console.log(result)
+})
+
+post('/submit', { foo: 'bar' })
+```

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,15 +1,9 @@
-import axios from 'axios'
+import { request, type ApiResponse } from './request'
 
-const instance = axios.create({ baseURL: '/api' })
-
-export type ApiResponse<T = any> = {
-    msg: string
-    result: T
-    status: string
-}
+export { ApiResponse }
 
 export const get = <T = any>(url: string, params?: any) =>
-    instance.get<ApiResponse<T>>(url, { params })
+    request<T>({ url, method: 'GET', params })
 
 export const post = <T = any>(url: string, data?: any) =>
-    instance.post<ApiResponse<T>>(url, data)
+    request<T>({ url, method: 'POST', data })

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -1,0 +1,39 @@
+import axios, { type AxiosInstance, type AxiosRequestConfig } from 'axios'
+import { message } from 'antd'
+import { useStore } from '@/stores'
+
+const instance: AxiosInstance = axios.create({
+    baseURL: '/api',
+    timeout: 10000
+})
+
+instance.interceptors.request.use((config) => {
+    const { token } = useStore.getState()
+    if (token) {
+        config.headers = {
+            ...config.headers,
+            Authorization: `Bearer ${token}`
+        }
+    }
+    return config
+})
+
+instance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        const msg = error.response?.data?.msg ?? '网络异常'
+        message.error(msg)
+        return Promise.reject(error)
+    }
+)
+
+export type ApiResponse<T = any> = {
+    msg: string
+    result: T
+    status: string
+}
+
+export const request = <T = any>(config: AxiosRequestConfig) =>
+    instance.request<ApiResponse<T>>(config)
+
+export default instance


### PR DESCRIPTION
## Summary
- 新增 `src/api/request.ts` 封装 axios 实例
- 调整 `src/api/index.ts` 使用统一请求方法
- 更新 `README` 说明基本使用方式

## Testing
- `pnpm run lint` *(fails: Cannot find package)*
- `npx prettier README.md src/api/index.ts src/api/request.ts -w` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_686bc682c07c83328fa43ba1b9f59b27